### PR TITLE
Preserve whitespace in <pre> tags

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -176,7 +176,7 @@ func (ctx *textifyTraverseCtx) handleElementNode(node *html.Node) error {
 
 		return ctx.emit("\n")
 
-	case atom.Pre, atom.Code:
+	case atom.Pre:
 		ctx.isPre = true
 		err := ctx.traverseChildren(node)
 		ctx.isPre = false

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -351,6 +351,10 @@ func TestHeadings(t *testing.T) {
 			"<h3> <span class='a'>Test </span></h3>",
 			"Test\n----",
 		},
+		{
+			"<pre>test1\ntest 2\n\ntest  3</pre>",
+			"test1\ntest 2\n\ntest  3",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -525,7 +529,7 @@ func TestText(t *testing.T) {
 			`hi
 
 			<br>
-	
+
 	hello <a href="https://google.com">google</a>
 	<br><br>
 	test<p>List:</p>


### PR DESCRIPTION
Html2text seems to discard the whitespace formatting in `<pre>` tags:

input:

```
<pre>test1
test 2

test  3</pre>
```

expected:

```
test1
test 2

test  3
```

actual result:

```
test1 test 2 test 3
```

- `<pre>` on MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
- Issue in upstream: https://github.com/jaytaylor/html2text/issues/6

So while HTML e-mails from our lunch menu notification channel look quite good…
![kookaburra_20171214_144946](https://user-images.githubusercontent.com/178133/33995404-2d2ca9b8-e0de-11e7-8dbe-cbe4d4e434ad.png)

…the plaintext ones are a mess:
![kookaburra_20171214_145005](https://user-images.githubusercontent.com/178133/33995409-32d1ccae-e0de-11e7-874c-1725e4ea4ac4.png)

Code taken from this patch: https://github.com/jaytaylor/html2text/issues/6#issuecomment-329620709Q
Added a simple test case with newlines and multiple spaces.